### PR TITLE
Update universe_env_wrapper.py

### DIFF
--- a/base_dqn_setup/universe_env_wrapper.py
+++ b/base_dqn_setup/universe_env_wrapper.py
@@ -1,4 +1,4 @@
-import baselines.common.atari_wrappers_deprecated as baseline
+from baselines.common.atari_wrappers import wrap_deepmind
 import gym
 import numpy as np
 


### PR DESCRIPTION
The " baselines.common.atari_wrappers_deprecated" Module no longer exists. Use the new one instead.